### PR TITLE
RHIDP-1167: Software template for creating a frontend plugin

### DIFF
--- a/templates.yaml
+++ b/templates.yaml
@@ -18,3 +18,4 @@ spec:
     - templates/github/register-component/template.yaml
     - templates/github/tekton/template.yaml
     - templates/github/techdocs/template.yaml
+    - templates/create-frontend-plugin/template.yaml

--- a/templates/create-frontend-plugin/docs/features/api.md
+++ b/templates/create-frontend-plugin/docs/features/api.md
@@ -1,0 +1,94 @@
+The ExampleFetchComponent demonstrates the common task of making an asynchronous request to a public API and displaying the response data in a table using Backstage components.
+
+You can modify these components, rename them, or replace them entirely.
+
+To consume APIs from your backend plugin, follow these steps:
+
+- Create an `api` folder under your `src` directory and add a client file for making API calls. The file name should follow the format `<PluginNameInTitleCase>BackendClient.ts`.
+
+  The file structure should be as follows:
+
+  ```ts title="<PluginNameInTitleCase>BackendClient.ts"
+
+      import {
+      ConfigApi,
+      createApiRef,
+      IdentityApi,
+      } from '@backstage/core-plugin-api';
+
+      // @public
+      export type <PluginNameInTitleCase>API = {
+      getUsers: () => Promise<{ status: string } | Response>;
+      };
+
+      export type Options = {
+      configApi: ConfigApi;
+      identityApi: IdentityApi;
+      };
+
+      // @public
+      export const <PluginNameInCamelCase>ApiRef = createApiRef<<PluginNameInTitleCase>API>({
+      id: 'plugin.<PluginNameInCamelCase>.service',
+      });
+
+      export class <PluginNameInTitleCase>BackendClient implements <PluginNameInTitleCase>API {
+
+      private readonly configApi: ConfigApi;
+      private readonly identityApi: IdentityApi;
+
+      constructor(options: Options) {
+          this.configApi = options.configApi;
+          this.identityApi = options.identityApi;
+      }
+
+      async getUsers() {
+          const { token: idToken } = await this.identityApi.getCredentials();
+          const backendUrl = this.configApi.getString('backend.baseUrl');
+          const jsonResponse = await fetch(`${backendUrl}/api/<mention-your-api-here>/`, {
+          headers: {
+              ...(idToken && { Authorization: `Bearer ${idToken}` }),
+          },
+          });
+          return jsonResponse.json();
+      }
+      }
+  ```
+
+- After creating the client, consume the APIs in your components:
+
+  ```tsx title="ExampleFetchComponent.tsx"
+
+      export const ExampleFetchComponent = () => {
+      const theme = useTheme();
+      const chipStyle = getChipStyle(theme);
+      const pluginApi = useApi(<PluginNameInCamelCase>ApiRef); // use the api ref created in the client file
+      const users = pluginApi.getUsers();
+      const columns: TableColumn[] = [
+          { title: 'Column title 1', field: 'column-field-1' },
+          { title: 'Column title 2', field: 'column-field-2' },
+          { title: 'Column title 3', field: 'column-field-3' },
+      ];
+
+      const data = users.map((user: any) => {
+          // prepare your table data here
+      });
+
+      return (
+          <Table
+          title="<table-title>"
+          options={{ search: false, paging: true }}
+          columns={columns}
+          data={data}
+          />
+      );
+      };
+
+  ```
+
+You may customize the components as needed to fit your requirements.
+
+## References
+
+- [RBAC frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac)
+
+- [Orchestrator frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator)

--- a/templates/create-frontend-plugin/docs/features/dynamic-plugin.md
+++ b/templates/create-frontend-plugin/docs/features/dynamic-plugin.md
@@ -1,0 +1,40 @@
+To be able to run your frontend plugin as a dynamic plugin on Red Hat Developer Hub, follow the steps below:
+
+- To build the plugin and the dynamic entrypoint:
+
+  `yarn install`
+
+  `yarn tsc`
+
+  `yarn build`
+
+  `yarn export-dynamic`
+
+- To install the dynamic plugin from a local build and run it in a local instance of backstage-showcase:
+
+  ```bash
+  cd dist-scalprum
+  npm pack .
+  archive=$(npm pack $pkg)
+  tar -xzf "$archive" && rm "$archive"
+  mv package $(echo $archive | sed -e 's:\.tgz$::')
+  ```
+
+- Move the resulting directory (janus-idp-backstage-plugin-<pluginName>-<version>) into the `dynamic-plugins-root` folder of your backstage-showcase clone, then run yarn start to start the app.
+
+- This configuration will then enable the plugin to be visible in the UI:
+
+  ```yaml
+  dynamicPlugins:
+    frontend:
+      janus-idp.backstage-plugin-<pluginName>:
+      appIcons:
+        - name: PluginIcon
+          importName: PluginIcon
+      dynamicRoutes:
+        - path: /<plugin-path>
+          importName: PluginPage
+          menuItem:
+            icon: PluginIcon
+            text: <PluginName>
+  ```

--- a/templates/create-frontend-plugin/docs/features/rbac.md
+++ b/templates/create-frontend-plugin/docs/features/rbac.md
@@ -1,0 +1,122 @@
+### Add new permissions to your plugin
+
+The available options for defining a permission include `resourceType`, `name`, and `attributes`. The `resourceType` is optional and should mainly be used if you are planning to attach conditional rules to the permissions. `name` is required and specifies the permission name. `attributes` are required, however the `action` defined within attributes section is optional. The available actions are `create`, `read`, `update`, and `delete`. If no action is specified, the RBAC Backend plugin will substitute `use` in its place. This means that any permission policies defined for the RBAC Backend plugin will appear as `p, role:default/<SOME_ROLE>, <MY_PERMISSION_WITHOUT_ACTION>, use, allow`.
+
+#### Steps
+
+- Create a new `plugin-common` using the Backstage CLI, if you do not already have one for your plugin.
+- Create the `permissions.ts` file and populate it with your permissions. An example has been provided below.
+
+```ts
+    import {createPermission } from ‘@backstage/plugin-permission-common’;
+
+    Export const ocmClusterReadPermission = createPermission({
+    name: ‘ocm.cluster.read’,
+    attributes: {
+        action: ‘read’,
+    },
+    });
+
+    export const ocmClusterPermissions = [ocmClusterReadPermission];
+```
+
+- In the `index.ts`, export the permissions that you have created.
+
+```ts title="index.ts"
+    export * from ‘./permissions’;
+```
+
+### Restrict access to your frontend plugin
+
+There are two ways, `usePermission` and `RequirePermission` that can be used to protect parts of your frontend plugin. `usePermission` can be used to determine if a user has the appropriate permissions to perform a certain action on the frontend. `RequirePermission` will render a child element if the user has the appropriate permission. Below are the examples of how to use the two mechanisms.
+
+#### `usePermission` to block access to editing a resource
+
+```ts
+    const getEditIcon = (isAllowed: boolean, roleName: string) => {
+    const { kind, name, namespace } = getKindNamespaceName(roleName);
+
+    return (
+        <EditRole
+        dataTestId={isAllowed ? 'update-policies' : 'disable-update-policies'}
+        roleName={roleName}
+        disable={!isAllowed}
+        to={`../../role/${kind}/${namespace}/${name}?activeStep=${2}`}
+        />
+    );
+    };
+
+    export const PermissionsCard = ({ entityReference }: PermissionsCardProps) => {
+    const { data, loading, retry, error } =
+        usePermissionPolicies(entityReference);
+    const [permissions, setPermissions] = React.useState<PermissionsData[]>();
+    const permissionResult = usePermission({ // check if the user has required permissions
+        permission: policyEntityUpdatePermission,
+        resourceRef: policyEntityUpdatePermission.resourceType,
+    });
+
+    // ... additional code ... //
+
+    const actions = [
+        {
+            icon: getRefreshIcon,
+            tooltip: 'Refresh',
+            isFreeAction: true,
+            onClick: () => {
+                retry.permissionPoliciesRetry();
+                retry.policiesRetry();
+            },
+        },
+        {
+            icon: () => getEditIcon(permissionResult.allowed, entityReference), // reference hook
+            tooltip: !permissionResult.allowed ? 'Unauthorized to edit' : 'Edit',
+            isFreeAction: true,
+            onClick: () => {},
+        },
+    ];
+
+    // ... additional code ... //
+```
+
+#### `RequirePermission` to block elements from rendering
+
+```ts
+    export const ClusterInfoCard = () => {
+    const { data } = useCluster();
+
+    if (!data) {
+        return null;
+    }
+
+    // ... Additional code ... //
+    return (
+        <RequirePermission permission={ocmEntityReadPermission}> // Block access to table
+            <TableCardFromData data={data} title="Cluster Info" nameMap={nameMap} />
+        </RequirePermission>
+    );
+```
+
+## References
+
+- [OCM frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm)
+- [RBAC frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac)
+- [Topology frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/topology)
+- [Youtube video on permissions framework](https://www.youtube.com/watch?v=BDoQhegtw6E)
+
+- [Permission Concepts](https://backstage.io/docs/permissions/concepts)
+
+Basic permissions:
+Examples:
+
+- [Catalog Permissions](https://github.com/backstage/backstage/blob/master/plugins/catalog-common/src/permissions.ts)
+- [Jenkins Permissions](https://github.com/backstage/backstage/blob/master/plugins/jenkins-common/src/permissions.ts)
+- [Devtools Permissions](https://github.com/backstage/backstage/blob/master/plugins/devtools-common/src/permissions.ts)
+- [Kubernetes Permissions](https://github.com/backstage/backstage/blob/master/plugins/kubernetes-common/src/permissions.ts)
+
+Condition permissions:
+Examples:
+
+- [Catalog Backend](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/permissions/conditionExports.ts)
+- [Playlist Backend](https://github.com/backstage/backstage/blob/c9ddf111a70fbbf286abe13081b67fc7719108d4/plugins/playlist-backend/src/permissions/conditions.ts#L20)
+- [Scaffolder Backend](https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/src/service/rules.ts)
+- [Upstream Documentation](https://backstage.io/docs/permissions/custom-rules)

--- a/templates/create-frontend-plugin/docs/features/theme.md
+++ b/templates/create-frontend-plugin/docs/features/theme.md
@@ -1,0 +1,96 @@
+You can customzie your application's response to light and dark modes using themes. Additionally, you can make use of theme to change the color palatte, typography size, font, and more.
+
+Backstage upstream ships with a “unified theme interface” that acts as a thin layer over Material theming, adding additional Backstage specific components and concerns to the underlying Material theming framework. This interface supports two versions of Material theming: v4 and v5.
+
+The theme set on the development backstage app isn’t set or available for any of the individual development setups, for example running the development setup for a plugin in the default light or dark upstream theme. Ideally, each of these development environments could pull in the same theme file so that regardless of how a given plugin UI is developed the developer is able to work with a consistent theme where UI components lay out and behave as expected. Fortunately, the `createDevApp` API that these environments rely on can also accept new themes.
+
+```ts
+createDevApp()
+  .addThemes([
+    {
+      id: "my-theme",
+      title: "My Custom Theme",
+      variant: "light",
+      icon: <LightIcon />,
+      Provider: ({ children }) => (
+        <UnifiedThemeProvider theme={myTheme} children={children} />
+      ),
+    },
+  ])
+  .registerApi({
+    // Additional code
+  });
+```
+
+`myTheme` would look like this:
+
+```ts title="myTheme.ts"
+import {
+  createBaseThemeOptions,
+  createUnifiedTheme,
+  palettes,
+} from "@backstage/theme";
+
+export const myTheme = createUnifiedTheme({
+  ...createBaseThemeOptions({
+    palette: {
+      ...palettes.light,
+      background: {
+        default: "#d5d6db",
+        paper: "#d5d6db",
+      },
+      banner: {
+        info: "#34548a",
+        error: "#8c4351",
+        text: "#343b58",
+        link: "#565a6e",
+      },
+      navigation: {
+        background: "#343b58",
+        indicator: "#8f5e15",
+        color: "#d5d6db",
+        selectedColor: "#ffffff",
+      },
+    },
+  }),
+  fontFamily: "Comic Sans MS",
+});
+```
+
+The `ExampleFetchComponent` leverages themes to alter the chip styles accordingly:
+
+```ts title="ExampleFetchComponent.tsx"
+import { Theme } from "@material-ui/core";
+import { useTheme } from "@material-ui/core/styles";
+
+export const getChipStyle = (theme: Theme) => {
+  return {
+    backgroundColor: theme.palette.type === "dark" ? "#3d5061" : "#e7f1fa",
+  };
+};
+
+export const DenseTable = ({ users }: any) => {
+  const theme = useTheme();
+  const chipStyle = getChipStyle(theme);
+
+  const data = users.map((user: any) => {
+    return {
+      id: user.login,
+      githubId: (
+        <Chip
+          style={chipStyle}
+          avatar={<Avatar alt={user.login} src={user.avatar_url} />}
+          label={user.login}
+          variant="outlined"
+        />
+      ),
+      repoUrl: user.html_url,
+      type: user.type,
+    };
+  });
+
+  // Additional code
+};
+```
+
+For more details on theming, refer to the [official documentation](https://backstage.io/docs/getting-started/app-custom-theme)

--- a/templates/create-frontend-plugin/docs/index.md
+++ b/templates/create-frontend-plugin/docs/index.md
@@ -1,0 +1,11 @@
+# Guide to kickstart frontend plugin development
+
+This Software Template guides you to kickstart your frontend plugin development with fewer clicks.
+
+Note: The template allows only `github.com` as host
+
+## Getting started
+
+This template gathers essential information from the user, such as the plugin ID, repository owner, and the repository name. It then checks if the repository already exists or if the user wants to create a new one. Upon execution, the template generates a folder structure with all the necessary files, dependencies, UI components, and unit tests to help you get started. This same folder structure is also created when you run `yarn new --select plugin` using the [Backstage CLI](https://backstage.io/docs/tooling/cli/commands#new). The template includes examples of how to fetch data from external sources, utilizing [Backstage components](https://backstage.io/storybook/), [Material UI](https://mui.com/material-ui/) and [Backstage Theme](https://backstage.io/docs/getting-started/app-custom-theme/).
+
+For more details on plugin development, check out the official [Backstage documentation](https://backstage.io/docs/plugins/).

--- a/templates/create-frontend-plugin/mkdocs.yml
+++ b/templates/create-frontend-plugin/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: "software-template"
+site_description: "User documentation for creating a frontend plugin"
+
+nav:
+  - Introduction: index.md
+  - Develop your Frontend Plugin with the following features:
+      - Guide to Consuming APIs in your UI Components: features/api.md
+      - Guide to Enforcing Access Controls in your Frontend Plugin: features/rbac.md
+      - Guide to Integrating Theme in your UI Components: features/theme.md
+      - Guide to Dynamic Plugin Enablement: features/dynamic-plugin.md
+
+plugins:
+  - techdocs-core

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/.eslintrc.js
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/README.md
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/README.md
@@ -1,0 +1,73 @@
+# ${{values.plugin_id}}
+
+Welcome to the ${{values.plugin_id}} plugin!
+
+_This plugin was created through the Software Template_
+
+## Getting started
+
+1. Go to the plugin directory and run `yarn install`
+
+
+### To access the plugin in isolation:
+
+1. Go to the plugin directory
+
+2. Run `yarn start`
+
+This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
+It is only meant for local development, and the setup for it can be found inside the [/dev](./dev) directory.
+
+
+### To access it from the Root of your backstage directory:
+
+
+1. Add the package in the `packages/app/package.json`
+
+  ```
+  "@janus-idp/backstage-plugin-${{values.plugin_id}}": "^0.1.0",
+  ```
+
+
+2. Add Route in `packages/app/src/App.tsx`:
+
+  ```tsx title="packages/app/src/App.tsx"
+   /* highlight-add-next-line */
+   import { PluginPage } from '@janus-idp/backstage-plugin-${{values.plugin_id}}';
+
+   <Route path="/${{values.plugin_id}}" element={<PluginPage />} />
+   ```
+
+3. Add your plugin as a Sidebar Item in `packages/app/src/components/Root/Root.tsx`:
+
+  ```tsx title="packages/app/src/components/Root/Root.tsx"
+   /* highlight-add-next-line */
+   import { PluginIcon } from '@janus-idp/backstage-plugin-${{values.plugin_id}}';
+
+   export const Root = ({ children }: PropsWithChildren<{}>) => (
+    <SidebarPage>
+      <Sidebar>
+        ...
+        <SidebarItem
+          icon={PluginIcon as IconComponent}
+          to="${{values.plugin_id}}"
+          text="${{values.plugin_id}}"
+        />
+        ...
+      <Sidebar>
+    </SidebarPage>
+   );
+  ```
+
+4. Set-up the Backstage Proxy. Follow https://backstage.io/docs/integrations/github/locations#token-scopes for creating personal access token
+
+  ```yaml title="app-config.yaml"
+  proxy:
+  ...
+  '/github':
+      target: 'https://api.github.com'
+      headers:
+          Authorization: 'token ${GITHUB_TOKEN}' 
+  ```
+
+5. Start your application from the root directory, and then navigate to [/${{values.plugin_id}}](http://localhost:3000/${{values.plugin_id}}).

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/app-config.janus-idp.yaml
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/app-config.janus-idp.yaml
@@ -1,0 +1,8 @@
+dynamicPlugins:
+  frontend:
+    janus-idp.backstage-plugin-${{values.plugin_id}}:
+      apiFactories: []
+      appIcons: []
+      dynamicRoutes: []
+      mountPoints: []
+      routeBindings: []

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/config.d.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/config.d.ts
@@ -1,0 +1,1 @@
+export interface Config {}

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/dev/index.tsx
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/dev/index.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { discoveryApiRef } from "@backstage/core-plugin-api";
+import { createDevApp } from "@backstage/dev-utils";
+import { TestApiProvider } from "@backstage/test-utils";
+import PermIdentityOutlinedIcon from "@mui/icons-material/PermIdentityOutlined";
+import { plugin, PluginPage } from "../src/plugin";
+
+const mockedDiscoveryApi = {
+  getBaseUrl: async (_param: any) => {
+    return "http://localhost:7007/api/proxy";
+  },
+};
+
+createDevApp()
+  .registerPlugin(plugin)
+  .addPage({
+    element: (
+      <TestApiProvider apis={[[discoveryApiRef, mockedDiscoveryApi]]}>
+        <PluginPage />
+      </TestApiProvider>
+    ),
+    title: "${{values.plugin_id}}",
+    path: "/${{values.plugin_id}}",
+    icon: () => <PermIdentityOutlinedIcon />,
+  })
+  .render();

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/package.json
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@janus-idp/backstage-plugin-${{values.plugin_id}}",
+  "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "export-dynamic": "janus-cli package export-dynamic-plugin",
+    "lint": "backstage-cli package lint",
+    "postpack": "backstage-cli package postpack",
+    "postversion": "yarn run export-dynamic",
+    "prepack": "backstage-cli package prepack",
+    "start": "backstage-cli package start",
+    "test": "backstage-cli package test --passWithNoTests --coverage",
+    "tsc": "tsc"
+  },
+  "dependencies": {
+    "@backstage/core-components": "^0.14.4",
+    "@backstage/core-plugin-api": "^1.9.2",
+    "@backstage/theme": "^0.5.5",
+    "@material-ui/core": "^4.9.13",
+    "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.61",
+    "@mui/icons-material": "^5.15.21",
+    "react-use": "^17.2.4"
+  },
+  "peerDependencies": {
+    "react": "16.13.1 || ^17.0.0 || ^18.0.0",
+    "react-router-dom": "^6.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "0.26.6",
+    "@backstage/core-app-api": "1.12.5",
+    "@backstage/dev-utils": "1.0.32",
+    "@backstage/test-utils": "1.5.5",
+    "@janus-idp/cli": "1.11.1",
+    "@testing-library/jest-dom": "6.0.0",
+    "@testing-library/react": "14.0.0",
+    "@testing-library/user-event": "14.0.0",
+    "msw": "1.0.0"
+  },
+  "files": [
+    "dist",
+    "config.d.ts",
+    "dist-scalprum",
+    "app-config.janus-idp.yaml"
+  ],
+  "configSchema": "config.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "${{values.repoUrl}}",
+    "directory": "${{values.plugin_id}}"
+  },
+  "keywords": [
+    "backstage",
+    "plugin"
+  ]
+}

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleComponent/ExampleComponent.test.tsx
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleComponent/ExampleComponent.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ExampleComponent } from './ExampleComponent';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { screen } from '@testing-library/react';
+import {
+  setupRequestMockHandlers,
+  renderInTestApp,
+} from "@backstage/test-utils";
+
+describe('ExampleComponent', () => {
+  const server = setupServer();
+  // Enable sane handlers for network requests
+  setupRequestMockHandlers(server);
+
+  // setup mock response
+  beforeEach(() => {
+    server.use(
+      rest.get('/*', (_, res, ctx) => res(ctx.status(200), ctx.json({}))),
+    );
+  });
+
+  it('should render', async () => {
+    await renderInTestApp(<ExampleComponent />);
+    expect(screen.getByText('Welcome to ${{values.plugin_id}}!')).toBeInTheDocument();
+  });
+});

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleComponent/ExampleComponent.tsx
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleComponent/ExampleComponent.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Typography, Grid, makeStyles } from "@material-ui/core";
+import {
+  InfoCard,
+  Header,
+  Page,
+  Content,
+  ContentHeader,
+  HeaderLabel,
+  SupportButton,
+} from "@backstage/core-components";
+import { ExampleFetchComponent } from "../ExampleFetchComponent";
+
+const usePaperStyles = makeStyles((theme) => ({
+  body: {
+    backgroundColor: theme.palette.background.paper,
+  },
+}));
+
+export const ExampleComponent = () => {
+  const classes = usePaperStyles();
+  return (
+    <Page themeId="tool">
+      <Header
+        title="Welcome to ${{values.plugin_id}}"
+        subtitle="Optional subtitle"
+      >
+        <HeaderLabel label="Owner" value="Team X" />
+        <HeaderLabel label="Lifecycle" value="Alpha" />
+      </Header>
+      <Content className={classes.body}>
+        <ContentHeader title="Plugin title">
+          <SupportButton>A description of your plugin goes here.</SupportButton>
+        </ContentHeader>
+        <Grid container spacing={3} direction="column">
+          <Grid item>
+            <InfoCard title="Information card">
+              <Typography variant="body1">
+                All content should be wrapped in a card like this.
+              </Typography>
+            </InfoCard>
+          </Grid>
+          <Grid item>
+            <ExampleFetchComponent />
+          </Grid>
+        </Grid>
+      </Content>
+    </Page>
+  );
+};

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleComponent/index.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleComponent/index.ts
@@ -1,0 +1,1 @@
+export { ExampleComponent } from './ExampleComponent';

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleComponentIcon.tsx
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleComponentIcon.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { SidebarItem } from '@backstage/core-components';
+import PermIdentityOutlinedIcon from '@mui/icons-material/PermIdentityOutlined';
+import { IconComponent } from '@backstage/core-plugin-api';
+
+
+export const ExampleComponentIcon = () => {
+
+  return (
+    <SidebarItem text="${{values.plugin_id}}" to="/${{values.plugin_id}}" icon={PermIdentityOutlinedIcon as IconComponent} />
+  );
+};

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleFetchComponent/ExampleFetchComponent.test.tsx
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleFetchComponent/ExampleFetchComponent.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ExampleFetchComponent } from './ExampleFetchComponent';
+
+describe('ExampleFetchComponent', () => {
+  it('renders the user table', async () => {
+    render(<ExampleFetchComponent />);
+
+    // Wait for the table to render
+    const table = await screen.findByRole('table');
+    const nationality = screen.getAllByText("GB")
+    // Assert that the table contains the expected user data
+    expect(table).toBeInTheDocument();
+    expect(screen.getByAltText('Carolyn')).toBeInTheDocument();
+    expect(screen.getByText('Carolyn Moore')).toBeInTheDocument();
+    expect(screen.getByText('carolyn.moore@example.com')).toBeInTheDocument();
+    expect(nationality[0]).toBeInTheDocument();
+  });
+});

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleFetchComponent/ExampleFetchComponent.tsx
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleFetchComponent/ExampleFetchComponent.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import useAsync from "react-use/lib/useAsync";
+import {
+  Table,
+  TableColumn,
+  Progress,
+  ResponseErrorPanel,
+} from "@backstage/core-components";
+import { discoveryApiRef, useApi } from "@backstage/core-plugin-api";
+import { Avatar, Chip } from "@material-ui/core";
+import { useTheme } from "@material-ui/core/styles";
+import { getChipStyle } from "../../utils/getChipStyle";
+
+type User = {
+  repoUrl: string;
+  githubId: string;
+  type: string;
+};
+
+export const DenseTable = ({ users }: any) => {
+  const theme = useTheme();
+  const chipStyle = getChipStyle(theme);
+  const columns: TableColumn[] = [
+    { title: "GithubId", field: "githubId" },
+    { title: "Repository URL", field: "repoUrl" },
+    { title: "Type", field: "type" },
+  ];
+
+  const data = users.map((user: any) => {
+    return {
+      id: user.login,
+      githubId: (
+        <Chip
+          style={chipStyle}
+          avatar={<Avatar alt={user.login} src={user.avatar_url} />}
+          label={user.login}
+          variant="outlined"
+        />
+      ),
+      repoUrl: user.html_url,
+      type: user.type,
+    };
+  });
+
+  return (
+    <Table
+      title="Github Users"
+      options={{ search: false, paging: true }}
+      columns={columns}
+      data={data}
+    />
+  );
+};
+
+export const ExampleFetchComponent = () => {
+  const discoveryApi = useApi(discoveryApiRef);
+  const proxyURL = discoveryApi.getBaseUrl("proxy");
+
+  const { value, loading, error } = useAsync(async (): Promise<User[]> => {
+    const res = await fetch(`${await proxyURL}/github/users`);
+    const users = await res.json();
+    return users;
+  }, []);
+
+  if (loading) {
+    return <Progress />;
+  } else if (error) {
+    return <ResponseErrorPanel error={error} />;
+  }
+
+  return <DenseTable users={value || []} />;
+};

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleFetchComponent/index.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/ExampleFetchComponent/index.ts
@@ -1,0 +1,1 @@
+export { ExampleFetchComponent } from './ExampleFetchComponent';

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/Router.tsx
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/Router.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+
+import { ExampleComponent } from './ExampleComponent';
+
+/**
+ *
+ * @public
+ */
+export const Router = () => (
+  <Routes>
+    <Route path="*" element={<ExampleComponent />} />
+  </Routes>
+);

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/index.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/components/index.ts
@@ -1,0 +1,4 @@
+export { Router } from './Router';
+export * from './ExampleComponent';
+export { ExampleComponentIcon } from './ExampleComponentIcon';
+

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/index.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/index.ts
@@ -1,0 +1,1 @@
+export { plugin, PluginPage } from './plugin';

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/plugin.test.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/plugin.test.ts
@@ -1,0 +1,7 @@
+import { plugin } from './plugin';
+
+describe('${{values.plugin_id}}', () => {
+  it('should export plugin', () => {
+    expect(plugin).toBeDefined();
+  });
+});

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/plugin.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/plugin.ts
@@ -1,0 +1,34 @@
+import {
+  createComponentExtension,
+  createPlugin,
+  createRoutableExtension,
+} from '@backstage/core-plugin-api';
+
+import { rootRouteRef } from './routes';
+
+export const plugin = createPlugin({
+  id: '${{values.plugin_id}}',
+  routes: {
+    root: rootRouteRef,
+  },
+});
+
+export const PluginPage = plugin.provide(
+  createRoutableExtension({
+    name: 'PluginPage',
+    component: () =>
+      import('./components').then(m => m.Router),
+    mountPoint: rootRouteRef,
+  }),
+);
+
+export const PluginIcon = plugin.provide(
+  createComponentExtension({
+    name: 'PluginIcon',
+    component: {
+      lazy: () => import('./components').then(m => m.ExampleComponentIcon),
+    },
+  }),
+);
+
+

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/routes.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/routes.ts
@@ -1,0 +1,5 @@
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+export const rootRouteRef = createRouteRef({
+  id: '${{values.plugin_id}}',
+});

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/setupTests.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/utils/getChipStyle.ts
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/src/utils/getChipStyle.ts
@@ -1,0 +1,7 @@
+import { Theme } from "@material-ui/core";
+
+export const getChipStyle = (theme: Theme) => {
+  return {
+    backgroundColor: theme.palette.type === "dark" ? "#3d5061" : "#e7f1fa",
+  };
+};

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/tsconfig.json
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["src", "dev", "migrations"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "../../dist-types/plugins/${{values.plugin_id}}",
+    "rootDir": "."
+  }
+}

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/turbo.json
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "tsc": {
+      "outputs": ["../../dist-types/plugins/${{values.plugin_id}}/**"],
+      "dependsOn": ["^tsc"]
+    }
+  }
+}

--- a/templates/create-frontend-plugin/template.yaml
+++ b/templates/create-frontend-plugin/template.yaml
@@ -1,0 +1,116 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: create-frontend-plugin
+  title: Create Frontend Plugin Template
+  description: Template for the scaffolder that creates a frontend plugin skeleton
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+  tags:
+    - frontend-plugin
+    - backstage-plugin
+spec:
+  owner: janus-authors
+  system: janus-idp
+  type: plugin
+
+  # These parameters are used to generate the input form in the frontend, and are
+  # used to gather input data for the execution of the template.
+  parameters:
+    - title: Provide some information
+      required:
+        - plugin_id
+      properties:
+        plugin_id:
+          title: Plugin ID
+          type: string
+          pattern: "^[a-z0-9-]*[a-z0-9]$"
+          description: Unique ID of the plugin.
+          ui:help: Plugin IDs must be lowercase and contain only letters, digits, and dashes.
+          ui:autofocus: true
+    - title: Choose a location
+      required:
+        - repoUrl
+      properties:
+        repoUrl:
+          title: Repository Location
+          type: string
+          ui:field: RepoUrlPicker
+          ui:options:
+            allowedHosts:
+              - github.com
+        pluginLocation:
+          type: string
+          title: Where to publish this new plugin?
+          ui:widget: radio
+          default: Create a new repository within the specified organization
+          enum:
+            - Submit a pull request to the same repository
+            - Create a new repository within the specified organization
+      dependencies:
+        pluginLocation:
+          allOf:
+            - if:
+                properties:
+                  pluginLocation:
+                    const: Submit a pull request to the same repository
+              then:
+                properties:
+                  branchName:
+                    title: Branch Name
+                    type: string
+                    description: The name for the branch
+                    default: ""
+                  targetBranchName:
+                    title: Target Branch Name
+                    type: string
+                    description: The target branch name of the merge request
+                    default: ""
+                # You can use additional fields of parameters within conditional parameters such as required.
+                required:
+                  - branchName
+                  - targetBranchName
+
+    # These steps are executed in the scaffolder backend, using data that we gathered
+    # via the parameters above.
+  steps:
+    # Each step executes an action
+    - id: template
+      name: Fetch Skeleton + Template
+      action: fetch:template
+      input:
+        url: ./skeleton
+        values:
+          plugin_id: ${{ parameters.plugin_id }}
+          repoUrl: ${{ parameters.repoUrl | parseRepoUrl }}
+
+    # This step publishes the contents of the working directory to GitHub if it is a new repository.
+    - id: publish
+      name: Publish the frontend plugin skeleton in a new repository
+      if: ${{ parameters.pluginLocation === 'Create a new repository within the specified organization' }}
+      action: publish:github
+      input:
+        allowedHosts: ["github.com"]
+        description: This is ${{ parameters.plugin_id }} frontend plugin.
+        repoUrl: ${{ parameters.repoUrl }}
+        sourcePath: plugins/${{parameters.plugin_id}}
+
+    # This step creates a pull request with the contents of the working directory.
+    - id: publishGithub
+      name: Create pull request with the frontend plugin skeleton
+      if: ${{ parameters.pluginLocation  === 'Submit a pull request to the same repository' }}
+      action: publish:github:pull-request
+      input:
+        repoUrl: ${{ parameters.repoUrl }}
+        branchName: ${{ parameters.branchName }}
+        targetBranchName: ${{ parameters.targetBranchName }}
+        title: Create frontend plugin ${{ parameters.plugin_id }}
+        description: This pull request creates the skeleton for your frontend plugin
+
+  # Outputs are displayed to the user after a successful execution of the template.
+  output:
+    links:
+      - title: View Plugin
+        url: ${{ steps.publish.output.remoteUrl }}
+      - title: View Pull Request
+        url: ${{ steps.publishGithub.output.remoteUrl }}


### PR DESCRIPTION
**Resolves**:
https://issues.redhat.com/browse/RHIDP-1167


**PR details:**
- This PR creates a software template to scaffold a frontend plugin skeleton.
- Users can push the plugin skeleton to a new repository or create a PR in an existing one.
- The `create-frontend-plugin` directory includes `techdocs` with guidelines on incorporating `Theme`, `RBAC`, and `API integration`.


**GIF:**
- Publishing the plugin skeleton in a new repo

https://github.com/user-attachments/assets/f42036cc-1b19-49e5-89c2-f152e1182794


- Creating a PR with the plugin skeleton in an existing repo

https://github.com/user-attachments/assets/66ddec6c-b28d-4b09-bf1a-5b99c5aebe06

Updated screens
<img width="1464" alt="Screenshot 2024-07-19 at 6 18 38 PM" src="https://github.com/user-attachments/assets/af6e0ad7-4020-4170-bd1a-3eace0b1d149">

<img width="1464" alt="Screenshot 2024-07-19 at 6 31 50 PM" src="https://github.com/user-attachments/assets/9b8d71f6-e632-441f-bd67-0d0fdeeb4548">

<img width="1464" alt="Screenshot 2024-07-19 at 6 31 25 PM" src="https://github.com/user-attachments/assets/5bff5457-8d1b-441b-90c3-74f06fee5f58">



Tech docs:


<img width="1464" alt="Screenshot 2024-07-19 at 6 54 51 PM" src="https://github.com/user-attachments/assets/0d377835-cf79-4040-8df3-5f14e32ffe22">




**Test setup:**

`app-config.yaml` changes
```
- type: url
  target: https://github.com/debsmita1/red-hat-developer-hub-software-templates/blob/scaffolder-fp/templates/create-frontend-plugin/template.yaml
  rules:
     - allow: [Template]
```