### PR TITLE
fix(create-backend-plugin): add missing backend suffix so that new pr contains the generated files

### DIFF
--- a/templates/create-backend-plugin/template.yaml
+++ b/templates/create-backend-plugin/template.yaml
@@ -87,7 +87,7 @@ spec:
         allowedHosts: ["github.com"]
         description: This is the ${{ parameters.plugin_id }} backend plugin.
         repoUrl: ${{ parameters.repoUrl }}
-        sourcePath: plugins/${{parameters.plugin_id}}
+        sourcePath: plugins/${{parameters.plugin_id}}-backend
 
     # This step creates a pull request with the contents of the working directory.
     - id: publishGithub


### PR DESCRIPTION
## What does this PR do / why we need it

There are two variants to create a new plugin with this templates

1. Open a new repository that contains just the content of the generated plugins folder. The `-backend` suffix was missed here.
2. A new PR that contains the full plugins/...-backend path. This case wasn't affected.

Recording:

https://github.com/user-attachments/assets/341d7560-eae0-4b28-8b42-b107a2b58551

## Which issue(s) does this PR fix

Fixes https://github.com/redhat-developer/red-hat-developer-hub-software-templates/pull/9#issuecomment-2243118940

## How to test changes / Special notes to the reviewer

Clone the repository, checkout the PR and link it locally with:

```yaml
catalog:
  locations:
    - type: file
      target: ../../../../../redhat-developer/red-hat-developer-hub-software-templates/templates/create-frontend-plugin/template.yaml
      rules:
        - allow: [Template]
    - type: file
      target: ../../../../../redhat-developer/red-hat-developer-hub-software-templates/templates/create-backend-plugin/template.yaml
      rules:
        - allow: [Template]
```

Or reference this PR with this catalog:

```yaml
catalog:
  locations:
    - type: url
      target: https://github.com/jerolimov/rhdh-software-templates/blob/fix-create-backend-plugin/templates/create-frontend-plugin/template.yaml
      rules:
        - allow: [Template]
    - type: url
      target: https://github.com/jerolimov/rhdh-software-templates/blob/fix-create-backend-plugin/templates/create-backend-plugin/template.yaml
      rules:
        - allow: [Template]
```
