### PR TITLE
[WIP] fix: fix backstage location format so that all templates are loaded correctly

### DIFF
--- a/templates.yaml
+++ b/templates.yaml
@@ -6,17 +6,17 @@ metadata:
 spec:
   type: url
   targets:
-    - templates/github/go-backend/template.yaml
-    - templates/github/nodejs-backend/template.yaml
-    - templates/gitlab/python-backend/template.yaml
-    - templates/azure/dotnet-frontend/template.yaml
-    - templates/github/spring-boot-backend/template.yaml
-    - templates/github/quarkus-backend/template.yaml
-    - templates/github/argocd/template.yaml
-    - templates/github/launch-ansible-job/template.yaml
-    - templates/github/define-ansible-job/template.yaml
-    - templates/github/register-component/template.yaml
-    - templates/github/tekton/template.yaml
-    - templates/github/techdocs/template.yaml
-    - templates/create-backend-plugin/template.yaml
-    - templates/create-frontend-plugin/template.yaml
+    - ./templates/github/go-backend/template.yaml
+    - ./templates/github/nodejs-backend/template.yaml
+    - ./templates/gitlab/python-backend/template.yaml
+    - ./templates/azure/dotnet-frontend/template.yaml
+    - ./templates/github/spring-boot-backend/template.yaml
+    - ./templates/github/quarkus-backend/template.yaml
+    - ./templates/github/argocd/template.yaml
+    - ./templates/github/launch-ansible-job/template.yaml
+    - ./templates/github/define-ansible-job/template.yaml
+    - ./templates/github/register-component/template.yaml
+    - ./templates/github/tekton/template.yaml
+    - ./templates/github/techdocs/template.yaml
+    - ./templates/create-backend-plugin/template.yaml
+    - ./templates/create-frontend-plugin/template.yaml


### PR DESCRIPTION
## What does this PR do / why we need it

I tried to import all included software template with:

```yaml
    - type: url
      target: https://github.com/jerolimov/rhdh-software-templates/blob/main/templates.yaml
      rules:
        - allow: [Template]
```

But it doesn't show any software template:

![image](https://github.com/user-attachments/assets/12d8c5b7-1e09-4ee5-a6fe-2d9504338c75)

With the changed location format (removed type and relative URLs) it shows all the templates correct:

```yaml
    - type: url
      target: https://github.com/jerolimov/rhdh-software-templates/blob/fix-templates/templates.yaml
      rules:
        - allow: [Template]
```



## Which issue(s) does this PR fix

Fixes #?

## How to test changes / Special notes to the reviewer

Include the yamls above into your catalog and open the Software template catalog.