### PR TITLE
RHIDP-1167: docs: update tech docs of new plugin templates

### DIFF
--- a/templates/create-backend-plugin/docs/features/auth_rbac.md
+++ b/templates/create-backend-plugin/docs/features/auth_rbac.md
@@ -1,8 +1,6 @@
 # Guide to Handle Authentication and Authorization
 
-
 This plugin exports two routes: `/health` and `/message`. The route `/health` is configured to have no authentication, and `/message` requires the user to be logged in. By default a route will require authentication, the client will have to add authentication tokens to access it, otherwise the route will respond with `401 Unauthorized`, meaning that the route requires an author (authentication), but was not able to identify it.
-
 
 ## Authorization
 
@@ -11,7 +9,7 @@ There are other cases where Authorization is required. It means that even being 
 Backstage provides a permission framework that can be used to add roles checking to a route. In order to use it you must first create a `permissions.ts` file that will export the required permissions to your route. Here's an example of a permission `read` for `ocm.cluster.read`
 
 ```ts
-import {createPermission } from '@backstage/plugin-permission-common';
+import { createPermission } from '@backstage/plugin-permission-common';
 
 export const ocmClusterReadPermission = createPermission({
   name: 'ocm.cluster.read',
@@ -24,6 +22,7 @@ export const ocmClusterPermissions = [ocmClusterReadPermission];
 ```
 
 Then make sure that the permission is exported from `index.ts`:
+
 ```ts
 export * from './permissions';
 ```
@@ -76,6 +75,7 @@ export const ocmPlugin = createBackendPlugin({
   },
 });
 ```
+
 In our `buildRouter` we must integrate permissions with the router using the constant `permissionsIntegrationRouter` with the permissions from our `permissions.ts` file:
 
 ```ts
@@ -99,21 +99,22 @@ const buildRouter = (
 ```
 
 After the permission integration router has been set, we will need to handle authorization within our Backend plugin. For this we create a method `authorize`, call it and and handle `DENY` results:
+
 ```ts
 const authorize = async (request: Request, permission: BasicPermission) => {
-    const decision = (
-        await permissions.authorize([{ permission: permission }], {
-        credentials: await httpAuth.credentials(request),
-        })
-    )[0];
-    return decision;
+  const decision = (
+    await permissions.authorize([{ permission: permission }], {
+      credentials: await httpAuth.credentials(request),
+    })
+  )[0];
+  return decision;
 }
 
 router.get('/myRoute', async (request, response) => {
-    const decision = await authorize(request, ocmEntityReadPermission);
-    if (decision.result === AuthorizeResult.DENY) {
-        throw new NotAllowedError('Unauthorized');
-    }
-    // Continue here if user is allowed...
+  const decision = await authorize(request, ocmEntityReadPermission);
+  if (decision.result === AuthorizeResult.DENY) {
+    throw new NotAllowedError('Unauthorized');
+  }
+  // Continue here if user is allowed...
 }
 ```

--- a/templates/create-backend-plugin/docs/features/export_to_rhdh.md
+++ b/templates/create-backend-plugin/docs/features/export_to_rhdh.md
@@ -6,11 +6,9 @@ This plugin is ready to be exported to run on Red Hat Developer Hub (RHDH) 1.2 u
 
 The dynamic plugins require the dev dependency `@janus-idp/cli` on the corresponding version for your target RHDH. This dependency will brings the command `janus-cli`, so a new script can be added to `package.json` to export dynamic plugins:
 
-
 ```json
 "export-dynamic": "janus-cli package export-dynamic-plugin --clean"
 ```
-
 
 ## Installation
 
@@ -23,6 +21,7 @@ global:
       - package: /path/to/plugin/root/dir
         disabled: false
 ```
+
 Please bear in mind that this way of installing plugins is a TechPreview and it may change in later RHDH releases. 
 
 For more information check [Dynamic Plugins](https://github.com/janus-idp/backstage-showcase/blob/main/showcase-docs/dynamic-plugins.md) documentation.

--- a/templates/create-backend-plugin/docs/features/extend.md
+++ b/templates/create-backend-plugin/docs/features/extend.md
@@ -14,14 +14,14 @@ When calling `registerInit` in `plugin.ts` it is possible to access other [servi
 
 ```ts
 env.registerInit({
-    deps: {
-        // services to be injected
-    },
-    async init({ 
-        // services are passed as parameters to init
-     }) {
-        // use the services here
-    };      
+  deps: {
+    // services to be injected
+  },
+  async init({
+    // services are passed as parameters to init
+  }) {
+    // use the services here
+  };      
 });
 ```
 
@@ -47,7 +47,5 @@ export const myCustomPluginIdModuleId = createBackendModule({
   },
 });
 ```
+
 So if you are looking to create actions, catalog processors or other extensions that are for a existing plugin, check if a module is not the suitable way of doing that.
-
-
-  

--- a/templates/create-backend-plugin/mkdocs.yml
+++ b/templates/create-backend-plugin/mkdocs.yml
@@ -1,11 +1,10 @@
-site_name: "software-template"
+site_name: "Create Backend Plugin Template"
 site_description: "User documentation for creating a back-end plugin"
 
 nav:
   - Introduction: index.md
-  - Develop your Backend Plugin with the following features:
-    - Guide to Understand And Extend Your Plugin: features/extend.md
-    - Guide to Handle Authentication and Authorization: features/auth_rbac.md
-    - Guide to Export Your Plugin to Red Hat Developer Hub: features/export_to_rhdh.md
+  - Understand And Extend Your Plugin: features/extend.md
+  - Handle Authentication and Authorization: features/auth_rbac.md
+  - Export Your Plugin to Red Hat Developer Hub: features/export_to_rhdh.md
 plugins:
   - techdocs-core

--- a/templates/create-frontend-plugin/docs/features/api.md
+++ b/templates/create-frontend-plugin/docs/features/api.md
@@ -1,3 +1,5 @@
+# Guide to Consuming APIs in your UI Components
+
 The ExampleFetchComponent demonstrates the common task of making an asynchronous request to a public API and displaying the response data in a table using Backstage components.
 
 You can modify these components, rename them, or replace them entirely.
@@ -9,80 +11,77 @@ To consume APIs from your backend plugin, follow these steps:
   The file structure should be as follows:
 
   ```ts title="<PluginNameInTitleCase>BackendClient.ts"
+  import {
+    ConfigApi,
+    createApiRef,
+    IdentityApi,
+  } from '@backstage/core-plugin-api';
 
-      import {
-      ConfigApi,
-      createApiRef,
-      IdentityApi,
-      } from '@backstage/core-plugin-api';
+  // @public
+  export type <PluginNameInTitleCase>API = {
+    getUsers: () => Promise<{ status: string } | Response>;
+  };
 
-      // @public
-      export type <PluginNameInTitleCase>API = {
-      getUsers: () => Promise<{ status: string } | Response>;
-      };
+  export type Options = {
+    configApi: ConfigApi;
+    identityApi: IdentityApi;
+  };
 
-      export type Options = {
-      configApi: ConfigApi;
-      identityApi: IdentityApi;
-      };
+  // @public
+  export const <PluginNameInCamelCase>ApiRef = createApiRef<<PluginNameInTitleCase>API>({
+    id: 'plugin.<PluginNameInCamelCase>.service',
+  });
 
-      // @public
-      export const <PluginNameInCamelCase>ApiRef = createApiRef<<PluginNameInTitleCase>API>({
-      id: 'plugin.<PluginNameInCamelCase>.service',
+  export class <PluginNameInTitleCase>BackendClient implements <PluginNameInTitleCase>API {
+
+    private readonly configApi: ConfigApi;
+    private readonly identityApi: IdentityApi;
+
+    constructor(options: Options) {
+      this.configApi = options.configApi;
+      this.identityApi = options.identityApi;
+    }
+
+    async getUsers() {
+      const { token: idToken } = await this.identityApi.getCredentials();
+      const backendUrl = this.configApi.getString('backend.baseUrl');
+      const jsonResponse = await fetch(`${backendUrl}/api/<mention-your-api-here>/`, {
+        headers: {
+          ...(idToken && { Authorization: `Bearer ${idToken}` }),
+        },
       });
-
-      export class <PluginNameInTitleCase>BackendClient implements <PluginNameInTitleCase>API {
-
-      private readonly configApi: ConfigApi;
-      private readonly identityApi: IdentityApi;
-
-      constructor(options: Options) {
-          this.configApi = options.configApi;
-          this.identityApi = options.identityApi;
-      }
-
-      async getUsers() {
-          const { token: idToken } = await this.identityApi.getCredentials();
-          const backendUrl = this.configApi.getString('backend.baseUrl');
-          const jsonResponse = await fetch(`${backendUrl}/api/<mention-your-api-here>/`, {
-          headers: {
-              ...(idToken && { Authorization: `Bearer ${idToken}` }),
-          },
-          });
-          return jsonResponse.json();
-      }
-      }
+      return jsonResponse.json();
+    }
+  }
   ```
 
 - After creating the client, consume the APIs in your components:
 
-  ```tsx title="ExampleFetchComponent.tsx"
+  ```ts title="ExampleFetchComponent.tsx"
+  export const ExampleFetchComponent = () => {
+    const theme = useTheme();
+    const chipStyle = getChipStyle(theme);
+    const pluginApi = useApi(<PluginNameInCamelCase>ApiRef); // use the api ref created in the client file
+    const users = pluginApi.getUsers();
+    const columns: TableColumn[] = [
+      { title: 'Column title 1', field: 'column-field-1' },
+      { title: 'Column title 2', field: 'column-field-2' },
+      { title: 'Column title 3', field: 'column-field-3' },
+    ];
 
-      export const ExampleFetchComponent = () => {
-      const theme = useTheme();
-      const chipStyle = getChipStyle(theme);
-      const pluginApi = useApi(<PluginNameInCamelCase>ApiRef); // use the api ref created in the client file
-      const users = pluginApi.getUsers();
-      const columns: TableColumn[] = [
-          { title: 'Column title 1', field: 'column-field-1' },
-          { title: 'Column title 2', field: 'column-field-2' },
-          { title: 'Column title 3', field: 'column-field-3' },
-      ];
+    const data = users.map((user: any) => {
+      // prepare your table data here
+    });
 
-      const data = users.map((user: any) => {
-          // prepare your table data here
-      });
-
-      return (
-          <Table
-          title="<table-title>"
-          options={{ search: false, paging: true }}
-          columns={columns}
-          data={data}
-          />
-      );
-      };
-
+    return (
+      <Table
+        title="<table-title>"
+        options={{ search: false, paging: true }}
+        columns={columns}
+        data={data}
+      />
+    );
+  };
   ```
 
 You may customize the components as needed to fit your requirements.
@@ -90,5 +89,4 @@ You may customize the components as needed to fit your requirements.
 ## References
 
 - [RBAC frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac)
-
 - [Orchestrator frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/orchestrator)

--- a/templates/create-frontend-plugin/docs/features/dynamic-plugin.md
+++ b/templates/create-frontend-plugin/docs/features/dynamic-plugin.md
@@ -1,3 +1,5 @@
+# Guide to Dynamic Plugin Enablement
+
 To be able to run your frontend plugin as a dynamic plugin on Red Hat Developer Hub, follow the steps below:
 
 - To build the plugin and the dynamic entrypoint:

--- a/templates/create-frontend-plugin/docs/features/rbac.md
+++ b/templates/create-frontend-plugin/docs/features/rbac.md
@@ -1,120 +1,121 @@
-### Add new permissions to your plugin
+# Guide to Enforcing Access Controls in your Frontend Plugin
+
+## Add new permissions to your plugin
 
 The available options for defining a permission include `resourceType`, `name`, and `attributes`. The `resourceType` is optional and should mainly be used if you are planning to attach conditional rules to the permissions. `name` is required and specifies the permission name. `attributes` are required, however the `action` defined within attributes section is optional. The available actions are `create`, `read`, `update`, and `delete`. If no action is specified, the RBAC Backend plugin will substitute `use` in its place. This means that any permission policies defined for the RBAC Backend plugin will appear as `p, role:default/<SOME_ROLE>, <MY_PERMISSION_WITHOUT_ACTION>, use, allow`.
 
-#### Steps
+### Steps
 
 - Create a new `plugin-common` using the Backstage CLI, if you do not already have one for your plugin.
 - Create the `permissions.ts` file and populate it with your permissions. An example has been provided below.
 
-```ts
-    import {createPermission } from ‘@backstage/plugin-permission-common’;
+  ```ts
+  import { createPermission } from ‘@backstage/plugin-permission-common’;
 
-    Export const ocmClusterReadPermission = createPermission({
+  export const ocmClusterReadPermission = createPermission({
     name: ‘ocm.cluster.read’,
     attributes: {
-        action: ‘read’,
+      action: ‘read’,
     },
-    });
+  });
 
-    export const ocmClusterPermissions = [ocmClusterReadPermission];
-```
+  export const ocmClusterPermissions = [ocmClusterReadPermission];
+  ```
 
 - In the `index.ts`, export the permissions that you have created.
 
-```ts title="index.ts"
-    export * from ‘./permissions’;
-```
+  ```ts title="index.ts"
+  export * from ‘./permissions’;
+  ```
 
-### Restrict access to your frontend plugin
+## Restrict access to your frontend plugin
 
 There are two ways, `usePermission` and `RequirePermission` that can be used to protect parts of your frontend plugin. `usePermission` can be used to determine if a user has the appropriate permissions to perform a certain action on the frontend. `RequirePermission` will render a child element if the user has the appropriate permission. Below are the examples of how to use the two mechanisms.
 
-#### `usePermission` to block access to editing a resource
+### `usePermission` to block access to editing a resource
 
 ```ts
-    const getEditIcon = (isAllowed: boolean, roleName: string) => {
-    const { kind, name, namespace } = getKindNamespaceName(roleName);
+const getEditIcon = (isAllowed: boolean, roleName: string) => {
+  const { kind, name, namespace } = getKindNamespaceName(roleName);
 
-    return (
-        <EditRole
-        dataTestId={isAllowed ? 'update-policies' : 'disable-update-policies'}
-        roleName={roleName}
-        disable={!isAllowed}
-        to={`../../role/${kind}/${namespace}/${name}?activeStep=${2}`}
-        />
-    );
-    };
+  return (
+    <EditRole
+      dataTestId={isAllowed ? 'update-policies' : 'disable-update-policies'}
+      roleName={roleName}
+      disable={!isAllowed}
+      to={`../../role/${kind}/${namespace}/${name}?activeStep=${2}`}
+    />
+  );
+};
 
-    export const PermissionsCard = ({ entityReference }: PermissionsCardProps) => {
-    const { data, loading, retry, error } =
-        usePermissionPolicies(entityReference);
-    const [permissions, setPermissions] = React.useState<PermissionsData[]>();
-    const permissionResult = usePermission({ // check if the user has required permissions
-        permission: policyEntityUpdatePermission,
-        resourceRef: policyEntityUpdatePermission.resourceType,
-    });
+export const PermissionsCard = ({ entityReference }: PermissionsCardProps) => {
+  const { data, loading, retry, error } = usePermissionPolicies(entityReference);
+  const [permissions, setPermissions] = React.useState<PermissionsData[]>();
+  const permissionResult = usePermission({ // check if the user has required permissions
+    permission: policyEntityUpdatePermission,
+    resourceRef: policyEntityUpdatePermission.resourceType,
+  });
 
-    // ... additional code ... //
+  // ... additional code ... //
 
-    const actions = [
-        {
-            icon: getRefreshIcon,
-            tooltip: 'Refresh',
-            isFreeAction: true,
-            onClick: () => {
-                retry.permissionPoliciesRetry();
-                retry.policiesRetry();
-            },
-        },
-        {
-            icon: () => getEditIcon(permissionResult.allowed, entityReference), // reference hook
-            tooltip: !permissionResult.allowed ? 'Unauthorized to edit' : 'Edit',
-            isFreeAction: true,
-            onClick: () => {},
-        },
-    ];
+  const actions = [
+    {
+      icon: getRefreshIcon,
+      tooltip: 'Refresh',
+      isFreeAction: true,
+      onClick: () => {
+        retry.permissionPoliciesRetry();
+        retry.policiesRetry();
+      },
+    },
+    {
+      icon: () => getEditIcon(permissionResult.allowed, entityReference), // reference hook
+      tooltip: !permissionResult.allowed ? 'Unauthorized to edit' : 'Edit',
+      isFreeAction: true,
+      onClick: () => {},
+    },
+  ];
 
-    // ... additional code ... //
+  // ... additional code ... //
 ```
 
-#### `RequirePermission` to block elements from rendering
+### `RequirePermission` to block elements from rendering
 
 ```ts
-    export const ClusterInfoCard = () => {
-    const { data } = useCluster();
+export const ClusterInfoCard = () => {
+  const { data } = useCluster();
 
-    if (!data) {
-        return null;
-    }
+  if (!data) {
+    return null;
+  }
 
-    // ... Additional code ... //
-    return (
-        <RequirePermission permission={ocmEntityReadPermission}> // Block access to table
-            <TableCardFromData data={data} title="Cluster Info" nameMap={nameMap} />
-        </RequirePermission>
-    );
+  // ... Additional code ... //
+  return (
+    <RequirePermission permission={ocmEntityReadPermission}> // Block access to table
+      <TableCardFromData data={data} title="Cluster Info" nameMap={nameMap} />
+    </RequirePermission>
+  );
+}
 ```
 
 ## References
+
+Additional documentation:
 
 - [OCM frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/ocm)
 - [RBAC frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/rbac)
 - [Topology frontend plugin](https://github.com/janus-idp/backstage-plugins/tree/main/plugins/topology)
 - [Youtube video on permissions framework](https://www.youtube.com/watch?v=BDoQhegtw6E)
-
 - [Permission Concepts](https://backstage.io/docs/permissions/concepts)
 
-Basic permissions:
-Examples:
+Basic permissions examples:
 
 - [Catalog Permissions](https://github.com/backstage/backstage/blob/master/plugins/catalog-common/src/permissions.ts)
 - [Jenkins Permissions](https://github.com/backstage/backstage/blob/master/plugins/jenkins-common/src/permissions.ts)
 - [Devtools Permissions](https://github.com/backstage/backstage/blob/master/plugins/devtools-common/src/permissions.ts)
 - [Kubernetes Permissions](https://github.com/backstage/backstage/blob/master/plugins/kubernetes-common/src/permissions.ts)
 
-Condition permissions:
-Examples:
+Condition permissions examples:
 
 - [Catalog Backend](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend/src/permissions/conditionExports.ts)
 - [Playlist Backend](https://github.com/backstage/backstage/blob/c9ddf111a70fbbf286abe13081b67fc7719108d4/plugins/playlist-backend/src/permissions/conditions.ts#L20)

--- a/templates/create-frontend-plugin/docs/features/theme.md
+++ b/templates/create-frontend-plugin/docs/features/theme.md
@@ -1,3 +1,5 @@
+# Guide to Integrating Theme in your UI Components
+
 You can customzie your application's response to light and dark modes using themes. Additionally, you can make use of theme to change the color palatte, typography size, font, and more.
 
 Backstage upstream ships with a “unified theme interface” that acts as a thin layer over Material theming, adding additional Backstage specific components and concerns to the underlying Material theming framework. This interface supports two versions of Material theming: v4 and v5.

--- a/templates/create-frontend-plugin/mkdocs.yml
+++ b/templates/create-frontend-plugin/mkdocs.yml
@@ -1,13 +1,12 @@
-site_name: "software-template"
+site_name: "Create Frontend Plugin Template"
 site_description: "User documentation for creating a frontend plugin"
 
 nav:
   - Introduction: index.md
-  - Develop your Frontend Plugin with the following features:
-      - Guide to Consuming APIs in your UI Components: features/api.md
-      - Guide to Enforcing Access Controls in your Frontend Plugin: features/rbac.md
-      - Guide to Integrating Theme in your UI Components: features/theme.md
-      - Guide to Dynamic Plugin Enablement: features/dynamic-plugin.md
+  - Consuming APIs in your UI Components: features/api.md
+  - Enforcing Access Controls in your Frontend Plugin: features/rbac.md
+  - Integrating Theme in your UI Components: features/theme.md
+  - Dynamic Plugin Enablement: features/dynamic-plugin.md
 
 plugins:
   - techdocs-core


### PR DESCRIPTION
## What does this PR do / why we need it

* Updated page title in the tech docs
* Simplified navigation (an extra level isn't needed for 4 items at all, right? Removed also the "Guide to" prefix from the navigation)
* Fixed some code example intentions and that code highlight didn't worked when ```tsx is used

Before:

https://github.com/user-attachments/assets/0c10c3b9-f5a1-4f8e-a0f3-bf5580956c65

After:

https://github.com/user-attachments/assets/b2d008f9-d043-49f5-9ef3-b1b0a036c6f7

## Which issue(s) does this PR fix

Fixes #?

## How to test changes / Special notes to the reviewer

Clone the repository, checkout the PR and link it locally with:

```yaml
catalog:
  locations:
    - type: file
      target: ../../../../../redhat-developer/red-hat-developer-hub-software-templates/templates/create-frontend-plugin/template.yaml
      rules:
        - allow: [Template]
    - type: file
      target: ../../../../../redhat-developer/red-hat-developer-hub-software-templates/templates/create-backend-plugin/template.yaml
      rules:
        - allow: [Template]
```

Or reference this PR with this catalog:

```yaml
catalog:
  locations:
    - type: url
      target: https://github.com/jerolimov/rhdh-software-templates/blob/update-tech-docs/templates/create-frontend-plugin/template.yaml
      rules:
        - allow: [Template]
    - type: url
      target: https://github.com/jerolimov/rhdh-software-templates/blob/update-tech-docs/templates/create-backend-plugin/template.yaml
      rules:
        - allow: [Template]
```
