### PR TITLE
Catalog info plugin template

### DIFF
--- a/templates/create-backend-plugin/skeleton/plugins/${{values.plugin_id}}-backend/catalog-info.yaml
+++ b/templates/create-backend-plugin/skeleton/plugins/${{values.plugin_id}}-backend/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.plugin_id }}
+  {%- if values.description %}
+  description: ${{ values.description }}
+  {%- endif %}
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: ${{ values.orgName }}/${{ values.repoName }}
+spec:
+  type: website
+  {%- if values.lifecycle %}
+  lifecycle: ${{ values.lifecycle }}
+  {%- else %}
+  lifecycle: production
+  {%- endif %}
+  owner: ${{ values.owner }}

--- a/templates/create-backend-plugin/template.yaml
+++ b/templates/create-backend-plugin/template.yaml
@@ -17,14 +17,28 @@ spec:
     - title: Provide some information
       required:
         - plugin_id
+        - owner
       properties:
         plugin_id:
           title: Plugin ID
           type: string
-          pattern: "^[a-z0-9-]*[a-z0-9]$"
+          pattern: '^[a-z0-9-]*[a-z0-9]$'
           description: Plugin unique ID.
           ui:help: Plugin IDs must be lowercase and contain only letters, digits, and dashes.
           ui:autofocus: true
+        description:
+          title: Description
+          type: string
+          description: Help others understand what this component is for
+        owner:
+          title: Owner
+          type: string
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              kind:
+                - Group
+                - User
     - title: Choose a location
       required:
         - repoUrl
@@ -54,12 +68,12 @@ spec:
                     title: Branch Name
                     type: string
                     description: The name for the branch
-                    default: ""
+                    default: ''
                   targetBranchName:
                     title: Target Branch Name
                     type: string
                     description: The target branch name of the merge request
-                    default: ""
+                    default: ''
                 # You can use additional fields of parameters within conditional parameters such as required.
                 required:
                   - branchName
@@ -77,6 +91,10 @@ spec:
         values:
           plugin_id: ${{ parameters.plugin_id }}
           repoUrl: ${{ parameters.repoUrl | parseRepoUrl }}
+          description: ${{ parameters.description }}
+          owner: ${{ parameters.owner }}
+          repoName: ${{ (parameters.repoUrl | parseRepoUrl).repo }}
+          orgName: ${{ (parameters.repoUrl | parseRepoUrl).owner }}
 
     # This step publishes the contents of the working directory to GitHub if it is a new repository.
     - id: publish
@@ -84,7 +102,7 @@ spec:
       if: ${{ parameters.is_existing_repo === false }}
       action: publish:github
       input:
-        allowedHosts: ["github.com"]
+        allowedHosts: ['github.com']
         description: This is the ${{ parameters.plugin_id }} backend plugin.
         repoUrl: ${{ parameters.repoUrl }}
         sourcePath: plugins/${{parameters.plugin_id}}-backend
@@ -101,6 +119,15 @@ spec:
         title: Create backend plugin ${{ parameters.plugin_id }}
         description: This pull request creates the skeleton for your backend plugin
 
+    # This step registers the component if the contents are being published to a new repository
+    - id: register
+      name: Registering the Catalog Info Component
+      if: ${{ parameters.is_existing_repo === false }}
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
@@ -108,3 +135,7 @@ spec:
         url: ${{ steps.publish.output.remoteUrl }}
       - title: View Pull Request
         url: ${{ steps.publishGithub.output.remoteUrl }}
+      - title: Open the Catalog Info Component
+        if: ${{ parameters.is_existing_repo === false }}
+        icon: catalog
+        entityRef: ${{ steps.register.output.entityRef }}

--- a/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/catalog-info.yaml
+++ b/templates/create-frontend-plugin/skeleton/plugins/${{values.plugin_id}}/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.plugin_id }}
+  {%- if values.description %}
+  description: ${{ values.description }}
+  {%- endif %}
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: ${{ values.orgName }}/${{ values.repoName }}
+spec:
+  type: website
+  {%- if values.lifecycle %}
+  lifecycle: ${{ values.lifecycle }}
+  {%- else %}
+  lifecycle: production
+  {%- endif %}
+  owner: ${{ values.owner }}

--- a/templates/create-frontend-plugin/template.yaml
+++ b/templates/create-frontend-plugin/template.yaml
@@ -20,14 +20,28 @@ spec:
     - title: Provide some information
       required:
         - plugin_id
+        - owner
       properties:
         plugin_id:
           title: Plugin ID
           type: string
-          pattern: "^[a-z0-9-]*[a-z0-9]$"
+          pattern: '^[a-z0-9-]*[a-z0-9]$'
           description: Unique ID of the plugin.
           ui:help: Plugin IDs must be lowercase and contain only letters, digits, and dashes.
           ui:autofocus: true
+        description:
+          title: Description
+          type: string
+          description: Help others understand what this component is for
+        owner:
+          title: Owner
+          type: string
+          ui:field: EntityPicker
+          ui:options:
+            catalogFilter:
+              kind:
+                - Group
+                - User
     - title: Choose a location
       required:
         - repoUrl
@@ -60,12 +74,12 @@ spec:
                     title: Branch Name
                     type: string
                     description: The name for the branch
-                    default: ""
+                    default: ''
                   targetBranchName:
                     title: Target Branch Name
                     type: string
                     description: The target branch name of the merge request
-                    default: ""
+                    default: ''
                 # You can use additional fields of parameters within conditional parameters such as required.
                 required:
                   - branchName
@@ -83,6 +97,10 @@ spec:
         values:
           plugin_id: ${{ parameters.plugin_id }}
           repoUrl: ${{ parameters.repoUrl | parseRepoUrl }}
+          description: ${{ parameters.description }}
+          owner: ${{ parameters.owner }}
+          repoName: ${{ (parameters.repoUrl | parseRepoUrl).repo }}
+          orgName: ${{ (parameters.repoUrl | parseRepoUrl).owner }}
 
     # This step publishes the contents of the working directory to GitHub if it is a new repository.
     - id: publish
@@ -90,7 +108,7 @@ spec:
       if: ${{ parameters.pluginLocation === 'Create a new repository within the specified organization' }}
       action: publish:github
       input:
-        allowedHosts: ["github.com"]
+        allowedHosts: ['github.com']
         description: This is ${{ parameters.plugin_id }} frontend plugin.
         repoUrl: ${{ parameters.repoUrl }}
         sourcePath: plugins/${{parameters.plugin_id}}
@@ -107,6 +125,15 @@ spec:
         title: Create frontend plugin ${{ parameters.plugin_id }}
         description: This pull request creates the skeleton for your frontend plugin
 
+    # This step registers the component if the contents are being published to a new repository
+    - id: register
+      name: Registering the Catalog Info Component
+      if: ${{ parameters.is_existing_repo === false }}
+      action: catalog:register
+      input:
+        repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
+        catalogInfoPath: /catalog-info.yaml
+
   # Outputs are displayed to the user after a successful execution of the template.
   output:
     links:
@@ -114,3 +141,7 @@ spec:
         url: ${{ steps.publish.output.remoteUrl }}
       - title: View Pull Request
         url: ${{ steps.publishGithub.output.remoteUrl }}
+      - title: Open the Catalog Info Component
+        if: ${{ parameters.is_existing_repo === false }}
+        icon: catalog
+        entityRef: ${{ steps.register.output.entityRef }}


### PR DESCRIPTION
## What does this PR do / why we need it

Adds the ability to register the backend and frontend plugins to the catalog that were created with the `create-backend-plugin` and `create-frontend-plugin` templates. 

We only attempt to register the plugins in the event that a new repository is opened. This is because, when using the existing repository option, retrieving the catalog info file from the branch based on the generated PR could be problematic in the event that the branch is deleted after merging.

## Which issue(s) does this PR fix

Fixes [RHIDP-4372](https://issues.redhat.com/browse/RHIDP-4372)

## How to test changes / Special notes to the reviewer
