### PR TITLE
Add AI-Powered Application Templates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,6 @@ Below is a table of templates along with their related tags and links to their r
 [Staged Deployment Patch Template](https://github.com/developer-hub-books/rhdh-book1-templates/tree/main/custom-deployment-patch) | Quarkus, Patch, Book, Deployment 
 [Create a NestJS Service with backing PostgreSQL Database](https://github.com/developer-hub-books/rhdh-book1-templates/tree/main/nestjs-with-postgres) | NodeJs, NestJS, Postgresql, Book, Database
 [Create Quarkus Service with hosted Angular Frontend](https://github.com/developer-hub-books/rhdh-book1-templates/tree/main/quarkus-with-angular) |	Java, Quarkus, Quinoa, Angular, Book
-
+[Create AI-Powered Application Templates](https://github.com/RHEcosystemAppEng/RHDH-templates/tree/main/scaffolder-templates) | RAG, Chatbot, OpenShift AI, Virtual Agent
 ## How to Contribute
 You can contribute to the template library by creating a pull request for enhancements/bug-fix. If you have suggestions for additional template or improvements, open up an issue.


### PR DESCRIPTION
- Added RHEcosystemAppEng/RHDH-templates repository link
- Added relevant tags: RAG, Chatbot, OpenShift AI, Virtual Agent

## What does this PR do / why we need it
This PR adds a new entry to the Red Hat Developer Hub Software Templates Library for AI-powered application templates from the RHEcosystemAppEng/RHDH-templates repository.
What it adds:
Link to AI-Powered Application Templates that include:

- RAG (Retrieval Augmented Generation) Chatbot templates
- AI Virtual Agent templates
- AI Metrics Summarizer templates
- Recommender system templates
Why we need it:
Provides developers with ready-to-use templates for building AI-powered applications
Leverages modern AI technologies like Llama Stack, OpenShift AI, RAG, and PGVector
Supports common AI use cases including chatbots, virtual agents, and metrics analysis
Follows the same template structure and best practices as other entries in the library
Technologies covered:
AI/ML frameworks (Llama Stack, OpenShift AI)
Vector databases (PGVector)
Monitoring integration (Prometheus)
Cloud-native AI deployment patterns
This addition expands the template library's coverage into the growing AI/ML application development space, providing developers with standardized starting points for AI-powered projects.
## Which issue(s) does this PR fix
https://issues.redhat.com/browse/APPENG-3727
Fixes #?

## How to test changes / Special notes to the reviewer
